### PR TITLE
Allow to filter chartsymbols by display-cat

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ bash generateShapefiles.sh [ENC_ROOT] [output_path]
 Working with enhanced data allows to create mapfiles from the chartsymbols.xml file. This file contains all the specification of all symbols of the IENC symbology and is provided by OpenCPN. The file provided by OpenCPN does contains a few errors or limitation that are not currently handled.
 
  - Only point layers are created from the chartsymbols.xml file. Line and polygon layers are still generated from template mapfile.
- - The layer order is not managed at all. The layers are added to the map in pseudo random order.
+ - The layer order is only managed at type levels. Points are on top, followed by lines and then polygons. The layers of each types are added to the map in pseudo random order.
  - The data files contain a MinScale / MaxScale information and this is not directly used. We currently separate in only 6 levels:
    - 2000000
    - 600000
@@ -102,13 +102,15 @@ Working with enhanced data allows to create mapfiles from the chartsymbols.xml f
  - Symbology can be created from vector and bitmaps. We are only supporting bitmap symbology.
  - TOWERSxx symbols are present twice in the chartsymbols.xml. We only use the second one.
  - SOUNDG labels are set with FORCE TRUE. This make to many appear in the map at small scale.
- - Some layers a wrong types
+ - Some text layers (SBDARE) contain numeric values that must be transformed to string.
+ - Some layers are exported as LINE instead of POLYGON
  - Some layers defined in the chartsymbols.xml are pointing to non-existing data columns:
    - BCNSPP layer (lookup #1781) uses BOYSHP == 1 Expression, but this field is not present. We replaced it by BCNDHP == 1.
    - BCNSPP layer (lookup #1784) uses CATLAM == 1 Expression, but this field is not present. We replaced it by CATSPM == 1.
    - RADSTA layer (lookup #1222, #2340) uses COMCHA field for label, but this field is not present. We replaced it by OBJNAM.
    - RDOSTA layer (lookup #2350) uses DGPS field for label, but this field is not present. We replaced it by OBJNAM.
    - TOPMAR layer uses OBJNAM field for label, but this field is not present
+   - SOUNDG layer is in display-cat Other, it has been transfered to Standard
 
 ## Generating Symbolset
 

--- a/chart-installation/generate_map_files/resources/chartsymbols/chartsymbols_S57.xml
+++ b/chart-installation/generate_map_files/resources/chartsymbols/chartsymbols_S57.xml
@@ -12770,7 +12770,7 @@
 			<radar-prio>On Top</radar-prio>
 			<table-name>Simplified</table-name>
 			<instruction>CS(SOUNDG02)</instruction>
-			<display-cat>Other</display-cat>
+			<display-cat>Standard</display-cat>
 			<comment>33010</comment>
 		</lookup>
 		<lookup id="1260" RCID="31312" name="SPLARE">
@@ -24538,7 +24538,7 @@
 			<radar-prio>On Top</radar-prio>
 			<table-name>Paper</table-name>
 			<instruction>CS(SOUNDG02)</instruction>
-			<display-cat>Other</display-cat>
+			<display-cat>Standard</display-cat>
 			<comment>33010</comment>
 		</lookup>
 		<lookup id="2378" RCID="30535" name="SPLARE">

--- a/chart-installation/generate_map_files/scripts/chartsymbols.py
+++ b/chart-installation/generate_map_files/scripts/chartsymbols.py
@@ -19,7 +19,7 @@ class ChartSymbols():
 
     root = None
 
-    def __init__(self, file, table='Simplified', color_table='DAY_BRIGHT'):
+    def __init__(self, file, table='Simplified', displaycategory=None, color_table='DAY_BRIGHT'):
         if not os.path.isfile(file):
             raise Exception('chartsymbol file do not exists')
         tree = etree.parse(file)
@@ -33,7 +33,7 @@ class ChartSymbols():
 
         self.load_color_table(root, color_table)
         self.load_symbols(root)
-        self.load_lookups(root, table)
+        self.load_lookups(root, table, displaycategory)
 
     def load_colors(self, color_table):
         self.color_table = {}
@@ -68,7 +68,7 @@ class ChartSymbols():
             except:
                 continue
 
-    def load_lookups(self, root, style):
+    def load_lookups(self, root, style, displaycategory=None):
         for lookup in root.iter('lookup'):
             try:
                 name = lookup.get('name')
@@ -87,7 +87,8 @@ class ChartSymbols():
                 continue
 
             # Only load points for now
-            if lookup_type == 'Point' and style == table_name:
+            if lookup_type == 'Point' and style == table_name and \
+               (displaycategory is None or display in displaycategory):
                 if not name in self.point_lookups:
                     self.point_lookups[name] = []
                 self.point_lookups[name].append({

--- a/chart-installation/generate_map_files/scripts/generate_map_config.py
+++ b/chart-installation/generate_map_files/scripts/generate_map_config.py
@@ -33,6 +33,7 @@ def parse_arguments():
     parser.add_argument("-rule-default-color", nargs=1, help="Substring that uniquely identifies a color table")
     parser.add_argument("-d", "--debug", action="store_true", help="Enable debug on the mapserver")
     parser.add_argument("-c", "--chartsymbols", nargs=1, help="Use OpenCPN chartsymbols.xml file to generate layers")
+    parser.add_argument("-y", "--displaycategory", nargs=1, help="Comma separated list of OpenCPN Display Category to load. Displaybase is always loaded, default is Standard.")
     parser.add_argument("-t", "--tablename", nargs=1, help="Which OpenCPN chartsymbols.xml table to generate. Default is Simplified.")
     args = parser.parse_args()
     if not ((args.basechart_data_path and args.rule_set_path) or
@@ -72,13 +73,18 @@ def main():
 
     chartsymbols = None
     tablename = 'Simplified'
+    displaycategory =['Displaybase']
     if args.chartsymbols and not os.path.isfile(args.chartsymbols[0]):
         print "chartsymbols.xml not found at: " + args.chartsymbols[0]
         sys.exit(1)
     elif args.chartsymbols and enhanced_data:
-        chartsymbols = args.chartsymbols[0]
+        chartsymbols = os.path.abspath(os.path.normpath(args.chartsymbols[0]))
         if args.tablename and args.tablename[0] in ['Simplified', 'Paper']:
             tablename = args.tablename[0]
+        if args.displaycategory:
+            displaycategory.extend(args.displaycategory[0].split(','))
+        else:
+            displaycategory.append('Standard')
 
     if not os.path.exists(data_path):
         os.makedirs(data_path)
@@ -101,7 +107,7 @@ def main():
         if not layer_definitions_exist or args.force_overwrite:
            create_layer_rules(resource_dir, os.path.join(rule_set_path, "layer_rules"))
         # Generate the BaseChart config ...
-        generate_basechart_config(data_path, map_path, rule_set_path, resource_dir, args.force_overwrite, args.debug, tablename, chartsymbols)
+        generate_basechart_config(data_path, map_path, rule_set_path, resource_dir, args.force_overwrite, args.debug, tablename, displaycategory, chartsymbols)
     elif args.geotif_data_path:
         # ... or the TIF config
         generate_tif_config(data_path, map_path, args.debug)


### PR DESCRIPTION
- Added `-y` option to filter chartsymbols.xml by display category. Default is Displaybase and Standard.
- Modify the xml to change SOUNDG layer from the `Other` display-cat to `Standard`.
- Fix a bug in specifying the path to chartsymbols.xml
- Make sure polygons are under lines and points are on top.