### PR TITLE
Exclude M_QUAL layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,11 @@ Working with enhanced data allows to create mapfiles from the chartsymbols.xml f
      and assumes a safety depth of 30 metres
  - Symbols in MapServer are anchored to the map in the center vs in the top-left corner for OpenCPN. This brings a disparity in the symbol placement when they are stacked together.
  - Current implementation stack levels as you zoom in so you get level 1 features and labels in level 2 maps.
- - Symbology can be created from vector and bitmaps. We are only supporting bitmap symbology.
+ - Symbology can be created from vector and bitmaps. We are only supporting bitmap symbology for points and vector symbology for lines and polygons.
  - TOWERSxx symbols are present twice in the chartsymbols.xml. We only use the second one.
  - SOUNDG labels are set with FORCE TRUE. This make to many appear in the map at small scale.
  - Some text layers (SBDARE) contain numeric values that must be transformed to string.
+ - Some layers are excluded from the map as they are useful in a WMS context. Right now only M_QUAL is excluded.
  - Some layers are exported as LINE instead of POLYGON
  - Some layers defined in the chartsymbols.xml are pointing to non-existing data columns:
    - BCNSPP layer (lookup #1781) uses BOYSHP == 1 Expression, but this field is not present. We replaced it by BCNDHP == 1.

--- a/chart-installation/generate_map_files/mapgen/chartsymbols.py
+++ b/chart-installation/generate_map_files/mapgen/chartsymbols.py
@@ -43,6 +43,8 @@ class ChartSymbols:
 
     polygon_lookups = {}
 
+    excluded_lookups = ['M_QUAL']
+
     root = None
 
     def __init__(self, file, point_table='Simplified', area_table='Plain',
@@ -133,6 +135,9 @@ class ChartSymbols:
                 )
                 display_priority = lookup.find('disp-prio').text
             except (KeyError, AttributeError):
+                continue
+
+            if name in self.excluded_lookups:
                 continue
 
             if table_name in (point_style, area_style, 'Lines') and \

--- a/chart-installation/generate_map_files/mapgen/cs.py
+++ b/chart-installation/generate_map_files/mapgen/cs.py
@@ -50,7 +50,7 @@ def DEPARE(lookup_type, name):
     # We are missing all the line and fill symbology
     return [{
         'instruction': AC('DEPIT'),
-        'rules': MSCompare('DRVAL2', '0', MSCompare.OP.LT),
+        'rules': MSCompare('DRVAL2', '0', MSCompare.OP.LE),
     }, {
         'instruction': AC('DEPVS'),
         'rules': MSCompare('DRVAL2', '10', MSCompare.OP.LT),

--- a/chart-installation/generate_map_files/scripts/chartsymbols.py
+++ b/chart-installation/generate_map_files/scripts/chartsymbols.py
@@ -41,6 +41,8 @@ class ChartSymbols():
 
     polygon_lookups = {}
 
+    excluded_lookups = ['M_QUAL']
+
     root = None
 
     mapfile_layer_template = """
@@ -155,6 +157,9 @@ END
                 rules = MSAnd(*(MSFilter.from_attrcode(attr.text)
                                 for attr in lookup.findall('attrib-code')))
             except (KeyError, AttributeError):
+                continue
+
+            if name in self.excluded_lookups:
                 continue
 
             if table_name in (point_style, area_style, 'Lines') and \

--- a/chart-installation/generate_map_files/scripts/cs.py
+++ b/chart-installation/generate_map_files/scripts/cs.py
@@ -51,7 +51,7 @@ def DEPARE(lookup_type, name):
     # We are missing all the line and fill symbology
     return [{
         'instruction': AC('DEPIT'),
-        'rules': MSCompare('DRVAL2', '0', MSCompare.OP.LT),
+        'rules': MSCompare('DRVAL2', '0', MSCompare.OP.LE),
     }, {
         'instruction': AC('DEPVS'),
         'rules': MSCompare('DRVAL2', '10', MSCompare.OP.LT),


### PR DESCRIPTION
- Exclude M_QUAL layer as it is not useful for WMS map
- Fix Intertidal zone colour in the DEPARE rules